### PR TITLE
Rewrite path on reading frame from file

### DIFF
--- a/src/main/java/lu/cnw/tcp_simulator/Play.java
+++ b/src/main/java/lu/cnw/tcp_simulator/Play.java
@@ -42,7 +42,7 @@ public class Play {
 
         for (FileFrame frame : frames) {
             if (frame.event == Event.FRAME) {
-                byte[] data = Files.readAllBytes(Path.of(frame.filename));
+                byte[] data = Files.readAllBytes(Path.of(INPUT_DIR).getParent().resolve(frame.filename));
 
                 long delay = (frame.timestamp - firstFrameTime) - (System.currentTimeMillis() - startTime);
                 if (delay > 0) {


### PR DESCRIPTION
This pull request includes a change to the `Play.java` file to improve the handling of file paths when reading frame data

* Modified the file path resolution in the `replayFrames` method to use the parent directory of `INPUT_DIR` for reading frame data

Not sure this is good practice but I'll give it a try